### PR TITLE
WIP: Twitter画面模写カスタマイズ中、Flexible で Text ラップでエラーになる

### DIFF
--- a/lib/components/tweetTitle.dart
+++ b/lib/components/tweetTitle.dart
@@ -33,7 +33,7 @@ class TweetTitle extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 4),
-              Text(generateNonce(min(30, Random().nextInt(100)))),
+              Flexible(child: Text(generateNonce(1000))),
               Row(
                 children: [
                   IconButton(


### PR DESCRIPTION
## やりたかったこと

Text が 長い時に折り返して表示したい。

## やったこと

Flexible で ラップした。
エラー出て解決できないので  [Flutter大学](https://github.com/flutteruniv/questions/issues/576) で質問させていただいてます。

## 補足情報

main は twitter 画面をカスタマイズしてます。
`generateNonce()` は引数`length`の文字数の文字列を作成します。
Textが画面外にはみ出してしまうので `min`で対応していた。